### PR TITLE
[Backport] Fix chown command to use colon for user and group separation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,7 @@ RUN apk --no-cache add \
 # Remove default server definition
     && rm /etc/nginx/http.d/default.conf \
 # Make sure files/folders needed by the processes are accessible when they run under the nobody user
-    && chown -R nobody.nobody /run \
-    && chown -R nobody.nobody /var/lib/nginx \
-    && chown -R nobody.nobody /var/log/nginx
+    && chown -R nobody:nobody /run /var/lib/nginx /var/log/nginx
 
 # Workaround for using gnu-iconv instead of iconv in PHP on Alpine
 # https://github.com/docker-library/php/issues/240#issuecomment-876464325


### PR DESCRIPTION
https://github.com/TrafeX/docker-php-nginx/pull/184