### PR TITLE
Increase FastCGI buffer to avoid error

### DIFF
--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -50,6 +50,9 @@ http {
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
 
         # Upload limit
         client_max_body_size ${client_max_body_size};


### PR DESCRIPTION
Avoid error due to long PHP messages e.g. notice and warning