### PR TITLE
Change PHP iconv to latest GNU version built from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG ARCH=
-FROM ${ARCH}alpine:3.24.1 AS build
+#FROM ${ARCH}alpine:3.24.1 AS build
 
-ARG GNU_LIBICONV_VERSION="=1.15-r3"
+#ARG GNU_LIBICONV_VERSION="=1.15-r3"
 
-RUN apk --no-cache add \
+#RUN apk --no-cache add \
 # Workaround for using gnu-iconv instead of iconv in PHP on Alpine
 # https://github.com/docker-library/php/issues/240#issuecomment-876464325
-      --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ \
-        gnu-libiconv${GNU_LIBICONV_VERSION}
+#      --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ \
+#        gnu-libiconv${GNU_LIBICONV_VERSION}
 
 FROM ${ARCH}alpine:3.24.1
 
@@ -78,6 +78,7 @@ RUN apk --no-cache add \
         # ${PHP_RUNTIME}-pdo_mysql \
         # ${PHP_RUNTIME}-pdo_sqlite \
         # ${PHP_RUNTIME}-bz2 \
+        gnu-libiconv \
 # Create symlink so programs depending on `php` and `php-fpm` still function
     && if [ ! -L /usr/bin/php ]; then ln -s /usr/bin/${PHP_RUNTIME} /usr/bin/php; fi \
     && if [ -d /etc/${PHP_RUNTIME} ]; then mv /etc/${PHP_RUNTIME} /etc/php && ln -s /etc/php /etc/${PHP_RUNTIME}; fi \
@@ -107,8 +108,11 @@ RUN apk --no-cache add \
 
 # Workaround for using gnu-iconv instead of iconv in PHP on Alpine
 # https://github.com/docker-library/php/issues/240#issuecomment-876464325
-COPY --from=build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
-ENV LD_PRELOAD=/usr/lib/preloadable_libiconv.so
+#COPY --from=build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
+#ENV LD_PRELOAD=/usr/lib/preloadable_libiconv.so
+# Replace stock musl-linked php iconv with the GNU libiconv build from the builder stage.
+# Runtime needs libiconv.so.2 (gnu-libiconv / gnu-libiconv-libs).
+COPY --from=erseco/alpine-php-webserver:3.23 /usr/lib/${PHP_RUNTIME}/modules/iconv.so /usr/lib/${PHP_RUNTIME}/modules/iconv.so
 
 # Add configuration files
 COPY --chown=nobody rootfs/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ ARG CURL_VERSION="=8.21.0-r0"
 ARG GETTEXT_VERSION="=1.0-r0"
 # renovate: datasource=repology depName=alpine_3_24/libssl3 versioning=loose
 ARG LIBSSL3_VERSION="=3.5.7-r0"
+# renovate: datasource=repology depName=alpine_3_24/gnu-libiconv versioning=loose
+ARG GNUICONV_VERSION="=1.18-r0"
 
 # Install packages
 RUN apk --no-cache add \
@@ -78,7 +80,7 @@ RUN apk --no-cache add \
         # ${PHP_RUNTIME}-pdo_mysql \
         # ${PHP_RUNTIME}-pdo_sqlite \
         # ${PHP_RUNTIME}-bz2 \
-        gnu-libiconv \
+        gnu-libiconv${GNUICONV_VERSION} \
 # Create symlink so programs depending on `php` and `php-fpm` still function
     && if [ ! -L /usr/bin/php ]; then ln -s /usr/bin/${PHP_RUNTIME} /usr/bin/php; fi \
     && if [ -d /etc/${PHP_RUNTIME} ]; then mv /etc/${PHP_RUNTIME} /etc/php && ln -s /etc/php /etc/${PHP_RUNTIME}; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ARG GETTEXT_VERSION="=1.0-r0"
 # renovate: datasource=repology depName=alpine_3_24/libssl3 versioning=loose
 ARG LIBSSL3_VERSION="=3.5.7-r0"
 # renovate: datasource=repology depName=alpine_3_24/gnu-libiconv versioning=loose
-ARG GNUICONV_VERSION="=1.18-r0"
+ARG GNU_LIBICONV_VERSION="=1.18-r0"
 
 # Install packages
 RUN apk --no-cache add \
@@ -80,7 +80,7 @@ RUN apk --no-cache add \
         # ${PHP_RUNTIME}-pdo_mysql \
         # ${PHP_RUNTIME}-pdo_sqlite \
         # ${PHP_RUNTIME}-bz2 \
-        gnu-libiconv${GNUICONV_VERSION} \
+        gnu-libiconv${GNU_LIBICONV_VERSION} \
 # Create symlink so programs depending on `php` and `php-fpm` still function
     && if [ ! -L /usr/bin/php ]; then ln -s /usr/bin/${PHP_RUNTIME} /usr/bin/php; fi \
     && if [ -d /etc/${PHP_RUNTIME} ]; then mv /etc/${PHP_RUNTIME} /etc/php && ln -s /etc/php /etc/${PHP_RUNTIME}; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
 ARG ARCH=
-#FROM ${ARCH}alpine:3.24.1 AS build
-
-#ARG GNU_LIBICONV_VERSION="=1.15-r3"
-
-#RUN apk --no-cache add \
-# Workaround for using gnu-iconv instead of iconv in PHP on Alpine
-# https://github.com/docker-library/php/issues/240#issuecomment-876464325
-#      --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ \
-#        gnu-libiconv${GNU_LIBICONV_VERSION}
-
 FROM ${ARCH}alpine:3.24.1
 
 LABEL org.opencontainers.image.title="alpine-php-nginx" \
@@ -108,11 +98,7 @@ RUN apk --no-cache add \
 # Make sure files/folders needed by the processes are accessible when they run under the nobody user
     && chown -R nobody:nobody /run /var/lib/nginx /var/log/nginx
 
-# Workaround for using gnu-iconv instead of iconv in PHP on Alpine
-# https://github.com/docker-library/php/issues/240#issuecomment-876464325
-#COPY --from=build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
-#ENV LD_PRELOAD=/usr/lib/preloadable_libiconv.so
-# Replace stock musl-linked php iconv with the GNU libiconv build from the builder stage.
+# Replace stock musl-linked php iconv with the GNU libiconv build from upstream.
 # Runtime needs libiconv.so.2 (gnu-libiconv / gnu-libiconv-libs).
 COPY --from=erseco/alpine-php-webserver:3.23 /usr/lib/${PHP_RUNTIME}/modules/iconv.so /usr/lib/${PHP_RUNTIME}/modules/iconv.so
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,7 @@ RUN apk --no-cache add \
     && chown -R nobody:nobody /run /var/lib/nginx /var/log/nginx
 
 # Replace stock musl-linked php iconv with the GNU libiconv build from upstream.
-# Runtime needs libiconv.so.2 (gnu-libiconv / gnu-libiconv-libs).
-COPY --from=erseco/alpine-php-webserver:3.23 /usr/lib/${PHP_RUNTIME}/modules/iconv.so /usr/lib/${PHP_RUNTIME}/modules/iconv.so
+COPY --from=ghcr.io/erseco/alpine-php-webserver:3.23 /usr/lib/${PHP_RUNTIME}/modules/iconv.so /usr/lib/${PHP_RUNTIME}/modules/iconv.so
 
 # Add configuration files
 COPY --chown=nobody rootfs/ /


### PR DESCRIPTION
Replace PHP iconv with upstream-build version with latest GNU libiconv instead of outdated Alpine-provided v1.15 for the fix of character encoding issue from the musl implementation.

Reference: https://github.com/erseco/alpine-php-webserver/pull/88