### PR TITLE
[Backport] fix: preserve forwarded public port for PHP runtime

### DIFF
--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -29,6 +29,13 @@ http {
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
 
+    # Preserve the public port provided by a reverse proxy when it is numeric.
+    # Fall back to the container listener when the header is absent or invalid.
+    map $http_x_forwarded_port $forwarded_server_port {
+        default $server_port;
+        "~^[0-9]{1,5}$" $http_x_forwarded_port;
+    }
+
     # Default server definition
     server {
         listen 8080 default_server;
@@ -88,8 +95,9 @@ http {
             fastcgi_index index.php;
             include fastcgi_params;
 
-            # Pass the original forwarded_scheme and HTTPS status to the PHP backend
+            # Pass the forwarded scheme, HTTPS status, and public port to the PHP backend
             fastcgi_param HTTP_X_FORWARDED_PROTO $forwarded_scheme;
+            fastcgi_param SERVER_PORT $forwarded_server_port;
             fastcgi_param HTTPS $https if_not_empty;
         }
 


### PR DESCRIPTION
Follow the nginx configuration change from erseco/alpine-php-webserver#96.

This adds an Nginx `map` for numeric `X-Forwarded-Port` values and passes the resulting value to PHP as `SERVER_PORT`, falling back to the container listener port when the header is absent or invalid.

This keeps PHP aware of the real public port when the application is behind a reverse proxy, while preserving the existing behavior for direct requests.