### PR TITLE
Fix auto-release tag selection on default branch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -51,7 +51,7 @@ jobs:
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: ${{ vars.RELEASE_BRANCHES }}
           FORCE_WITHOUT_CHANGES: true
-          TAG_CONTEXT: branch
+          TAG_CONTEXT: repo
 
       - name: Set next version
         id: next_tag_version
@@ -117,7 +117,7 @@ jobs:
       - name: Get commit SHA of last tag and last commit
         id: get_commit_sha
         run: |
-          LAST_TAG=`git tag --points-at $(git rev-list --tags --max-count=1) | sort | tail -1`
+          LAST_TAG="${{ steps.next_tag_version.outputs.previous_tag }}"
           LAST_TAG_COMMIT=`git rev-list -n 1 $LAST_TAG`
           echo "previous_tag=$LAST_TAG" >> $GITHUB_OUTPUT
           echo "previous_tag_commit=$LAST_TAG_COMMIT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix the auto-release workflow's previous-tag handling for the default branch.

Changes:
- Use `TAG_CONTEXT: repo` so `anothrNick/github-tag-action` selects the highest SemVer tag by value rather than the branch-context commit-date ordering.
- Reuse `next_tag_version.previous_tag` in `get_commit_sha` instead of independently selecting a tag by commit history.

This intentionally does not address independent maintenance branches such as `php8.3`; that case is parked for a separate change.