### PR TITLE
Update auto-release bot secret inputs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,9 +7,9 @@ on:
         required: true
         type: string
     secrets:
-      RELEASE_BOT_APP_ID:
+      bot-client-id:
         required: true
-      RELEASE_BOT_PRIVATE_KEY:
+      bot-private-key:
         required: true
   #push:
   #  branches: ["fix/auto-release"]
@@ -33,8 +33,8 @@ jobs:
         id: generate_release_token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          client-id: ${{ secrets.bot-client-id }}
+          private-key: ${{ secrets.bot-private-key }}
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,8 +65,8 @@ jobs:
     with:
       image: ${{ vars.REGISTRY_NIGHTLY }}/${{ github.repository }}:nightly
     secrets:
-      RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
-      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+      bot-client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+      bot-private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
   # Prevent accidental deletion by not using dynamic Action variables
   housekeep-nightly-containers:


### PR DESCRIPTION
## Changes

- Rename `auto-release` workflow-call secret inputs:
  - `RELEASE_BOT_APP_ID` → `bot-client-id`
  - `RELEASE_BOT_PRIVATE_KEY` → `bot-private-key`
- Update `nightly` to use the renamed workflow-call secret inputs.
- Pass the repository secret `RELEASE_BOT_CLIENT_ID` into `bot-client-id`.

Only `.github/workflows/auto-release.yml` and `.github/workflows/nightly.yml` are changed.